### PR TITLE
🩹 엔티티를 수정하고 회원가입으로 진입할 때 필요한 메서드를 수정해요.

### DIFF
--- a/Projects/AppFeature/Login/Targets/Scene/Sources/LoginViewController.swift
+++ b/Projects/AppFeature/Login/Targets/Scene/Sources/LoginViewController.swift
@@ -51,7 +51,10 @@ extension LoginViewController {
                     ProfileEditSceneBuilder(
                         navigationController: navigationController
                     )
-                    .showProfileEditScene(from: self)
+                    .showProfileEditScene(
+                        socialType: .kakao,
+                        from: self
+                    )
                 }
             }
     }

--- a/Projects/AppFeature/ProfileEdit/Targets/Scene/Sources/Domain/Entity/EditingProfile.swift
+++ b/Projects/AppFeature/ProfileEdit/Targets/Scene/Sources/Domain/Entity/EditingProfile.swift
@@ -25,7 +25,7 @@ extension EditingProfile {
         public var birth: Int?
         public var gender: Gender?
         public var job: Job?
-        public var worry: Worry?
+        public var worryList: [Worry] = []
     }
 
     public enum Gender {

--- a/Projects/AppFeature/ProfileEdit/Targets/Scene/Sources/ProfileEditSceneBuilder.swift
+++ b/Projects/AppFeature/ProfileEdit/Targets/Scene/Sources/ProfileEditSceneBuilder.swift
@@ -39,8 +39,13 @@ public final class ProfileEditSceneBuilder {
 
 extension ProfileEditSceneBuilder {
     public func showProfileEditScene(
+        socialType: EditingProfile.SocialType? = nil, // Note: 회원가입인 경우 socialType을 주입합니다.
         from viewController: UIViewController
     ) {
+        if let socialType {
+            dataStore.editingProfile = EditingProfile(socialType: socialType, profileInfo: .init())
+        }
+
         let startViewController = nicknameViewController()
 
         // Note: Set up navigation (로그인에서 설정된다면 제거 필요)


### PR DESCRIPTION
### 📃 전달 사항

- 회원가입으로 진입할 때, socialType은 필수로 필요해여. socialType을 받아오도록 파라미터에 추가합니당
- 고민거리가 하나만 입력가능한 줄 알았는데 2개라서 Array로 수정합니당


### 📸 스크린샷

x

### ✔ 진행사항
- [x] ProfileEdit 진입 메서드 수정
- [x] EditingProfile Entity 수정


### 🔴 ETC

x


### 💻 개발환경
macOS: Sonoma 14.0
xcode: 15.0
iOS: iphone 15 pro simulator


<hr>

closes: #
