### PR TITLE
✨ 회원가입 플로우 - (1) 닉네임 입력 화면

### DIFF
--- a/Projects/AppFeature/ProfileEdit/Targets/Scene/Sources/Domain/Entity/EditingProfile.swift
+++ b/Projects/AppFeature/ProfileEdit/Targets/Scene/Sources/Domain/Entity/EditingProfile.swift
@@ -22,6 +22,7 @@ extension EditingProfile {
 
 extension EditingProfile {
     public struct ProfileInfo {
+        public var nickname: String?
         public var birth: Int?
         public var gender: Gender?
         public var job: Job?

--- a/Projects/AppFeature/ProfileEdit/Targets/Scene/Sources/Scenes/Common Views/HeaderView.swift
+++ b/Projects/AppFeature/ProfileEdit/Targets/Scene/Sources/Scenes/Common Views/HeaderView.swift
@@ -1,0 +1,143 @@
+//
+//  HeaderView.swift
+//  ProfileEditScene
+//
+//  Created by Woody Lee on 6/23/24.
+//  Copyright © 2024 tellingUs. All rights reserved.
+//
+
+import Combine
+import SnapKit
+import Then
+import UIKit
+
+import AppCore_DesignSystem
+import SharedKit
+
+final class HeaderView: UIView {
+    let stackView = UIStackView()
+    let captionLabel = UILabel()
+    let titleLabel = UILabel()
+    let descriptionLabel = UILabel()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Set up
+
+extension HeaderView {
+    private func setupUI() {
+        stackView.do {
+            $0.axis = .vertical
+            $0.spacing = Const.captionTitleSpacing
+            $0.alignment = .fill
+            $0.distribution = .fill
+            $0.setCustomSpacing(Const.titleDescriptionSpacing, after: titleLabel)
+
+            $0.addArrangedSubview(captionLabel)
+            $0.addArrangedSubview(titleLabel)
+            $0.addArrangedSubview(descriptionLabel)
+
+            addSubview($0)
+            $0.snp.makeConstraints { make in
+                make.directionalEdges.equalToSuperview()
+            }
+        }
+    }
+}
+
+// MARK: - Configure
+
+extension HeaderView {
+    enum Content {
+        case nickname
+        case birthGender
+        case job
+        case worry
+    }
+
+    func configure(content: Content) {
+        captionLabel.setText(
+            text: content.caption,
+            style: .caption_01_B,
+            textColor: .primary400
+        )
+
+        titleLabel.setText(
+            text: content.title,
+            style: .head_02_B,
+            textColor: .gray600
+        )
+        
+        descriptionLabel.setText(
+            text: content.description,
+            style: .body_02_R,
+            textColor: .gray600
+        )
+
+        captionLabel.numberOfLines = 0
+        titleLabel.numberOfLines = 0
+        descriptionLabel.numberOfLines = 0
+
+        captionLabel.isHidden = content.caption == nil
+        descriptionLabel.isHidden = content.description == nil
+    }
+}
+
+// MARK: - Const
+
+extension HeaderView {
+    private enum Const {
+        static let captionTitleSpacing = 2.0
+        static let titleDescriptionSpacing = 4.0
+    }
+}
+
+extension HeaderView.Content {
+    var title: String {
+        switch self {
+        case .nickname:
+            return "닉네임을 입력해주세요"
+        case .birthGender:
+            return "출생연도와 성별을 알려주세요"
+        case .job:
+            return "직업을 선택해주세요"
+        case .worry:
+            return "고민을 선택해주세요"
+        }
+    }
+
+    var description: String? {
+        switch self {
+        case .nickname:
+            return "닉네임은 이후에도 변경 가능해요"
+        case .birthGender:
+            return nil
+        case .job:
+            return "나와 비슷한 텔러들의 이야기를 먼저 확인할 수 있어요\n(마이페이지에서 변경 가능)"
+        case .worry:
+            return "나와 비슷한 텔러들의 이야기를 먼저 확인할 수 있어요\n(마이페이지에서 변경 가능)"
+        }
+    }
+
+    var caption: String? {
+        switch self {
+        case .nickname:
+            return nil
+        case .birthGender:
+            return nil
+        case .job:
+            return nil
+        case .worry:
+            return "최대 2가지 선택 가능"
+        }
+    }
+}

--- a/Projects/AppFeature/ProfileEdit/Targets/Scene/Sources/Scenes/Common Views/ProfileEditViewController.swift
+++ b/Projects/AppFeature/ProfileEdit/Targets/Scene/Sources/Scenes/Common Views/ProfileEditViewController.swift
@@ -1,0 +1,166 @@
+//
+//  ProfileEditViewController.swift
+//  ProfileEditScene
+//
+//  Created by Woody Lee on 6/23/24.
+//  Copyright © 2024 tellingUs. All rights reserved.
+//
+
+import Combine
+import SnapKit
+import Then
+import UIKit
+
+import AppCore_DesignSystem
+import SharedKit
+
+class ProfileEditViewController: UIViewController {
+    var cancellables = Set<AnyCancellable>()
+
+    private(set) var scrollView = UIScrollView()
+    private(set) var contentView = UIView()
+    private(set) var headerView = HeaderView()
+    private(set) var nextButton = BoxButton(text: "다음", attributes: .primaryLarge)
+
+    private var keyboardAnimationHandler: KeyboardAnimationHandler?
+    private var buttonBottomInsetConstraint: Constraint?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        setupUI()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        bind()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        view.endEditing(true)
+    }
+
+    func setupUI() {
+        view.backgroundColor = .white
+
+        scrollView.do {
+            $0.delaysContentTouches = false
+            $0.alwaysBounceVertical = false
+
+            view.addSubview($0)
+            $0.snp.makeConstraints { make in
+                make.directionalEdges.equalTo(view.safeAreaLayoutGuide)
+            }
+        }
+
+        contentView.do {
+            scrollView.addSubview($0)
+            $0.snp.makeConstraints { make in
+                make.directionalEdges.equalToSuperview()
+                make.width.equalToSuperview()
+                make.height.equalToSuperview().priority(.init(200))
+            }
+        }
+
+        headerView.do {
+            contentView.addSubview($0)
+
+            $0.snp.makeConstraints { make in
+                make.top.equalToSuperview().offset(Const.topSpacing)
+                make.directionalHorizontalEdges.equalToSuperview().inset(Const.contentInsets)
+            }
+        }
+
+        nextButton.do {
+            $0.isEnabled = false
+
+            view.addSubview($0)
+            $0.snp.makeConstraints { make in
+                buttonBottomInsetConstraint = make.bottom
+                    .equalTo(view.safeAreaLayoutGuide)
+                    .inset(buttonBottomInset)
+                    .constraint
+                make.directionalHorizontalEdges.equalToSuperview().inset(horizontalInsets)
+            }
+        }
+    }
+
+    func bind() {
+        NotificationCenter.default
+            .publisher(for: UIResponder.keyboardWillHideNotification)
+            .sink { [weak self] in self?.animateButton(notification: $0) }
+            .store(in: &cancellables)
+
+        NotificationCenter.default
+            .publisher(for: UIResponder.keyboardWillShowNotification)
+            .sink { [weak self] in self?.animateButton(notification: $0) }
+            .store(in: &cancellables)
+    }
+}
+
+// MARK: - Keyboard animation
+
+extension ProfileEditViewController {
+    typealias KeyboardAnimationTuple = (Double, UIView.AnimationCurve, CGFloat)
+    typealias KeyboardAnimationHandler = (KeyboardAnimationTuple) -> Void
+
+    func configureKeyboardAnimation(_ animationHandler: @escaping KeyboardAnimationHandler) {
+        self.keyboardAnimationHandler = animationHandler
+    }
+
+    private func animateButton(notification: Notification) {
+        guard let (duration, curve, height) = getAnimationProperties(notification: notification)
+        else { return }
+
+        let buttonBottomInset = height == .zero ? buttonBottomInset : -buttonBottomInset
+        let inset = height + buttonBottomInset
+        buttonBottomInsetConstraint?.update(inset: inset)
+
+        UIViewPropertyAnimator(
+            duration: duration,
+            curve: curve,
+            animations: { self.view.layoutIfNeeded() }
+        )
+        .startAnimation()
+
+        keyboardAnimationHandler?((duration, curve, height))
+    }
+
+    private func getAnimationProperties(notification: Notification) -> KeyboardAnimationTuple? {
+        let willHideNotificationName = UIResponder.keyboardWillHideNotification
+        let durationKey = UIResponder.keyboardAnimationDurationUserInfoKey
+        let curveKey = UIResponder.keyboardAnimationCurveUserInfoKey
+        let frameKey = UIResponder.keyboardFrameEndUserInfoKey
+
+        guard let userInfo = notification.userInfo,
+              let duration = userInfo[durationKey] as? Double,
+              let curveValue = userInfo[curveKey] as? Int,
+              let curve = UIView.AnimationCurve(rawValue: curveValue),
+              let keyboardFrame = userInfo[frameKey] as? CGRect
+        else { return nil }
+
+        let height: CGFloat = notification.name == willHideNotificationName ? .zero : keyboardFrame.height
+        return (duration, curve, height)
+    }
+}
+
+// MARK: - Const
+
+extension ProfileEditViewController {
+    var horizontalInsets: CGFloat {
+        Const.contentInsets
+    }
+
+    var buttonBottomInset: CGFloat {
+        Const.buttonBottomInset
+    }
+
+    enum Const {
+        static let contentInsets = 20.0
+        static let topSpacing = 30.0
+        static let buttonBottomInset = 16.0
+    }
+}

--- a/Projects/AppFeature/ProfileEdit/Targets/Scene/Sources/Scenes/Nickname/ProfileEditNicknameInteractor.swift
+++ b/Projects/AppFeature/ProfileEdit/Targets/Scene/Sources/Scenes/Nickname/ProfileEditNicknameInteractor.swift
@@ -12,11 +12,16 @@ import Foundation
 import AppCore_Entity
 import SharedKit
 
-protocol ProfileEditNicknameBusinessLogic {}
+protocol ProfileEditNicknameBusinessLogic {
+    func loadIfNeeded()
+    func verifyNickname(_ nickname: String)
+}
 
 protocol ProfileEditNicknameDataStore: AnyObject {}
 
-final class ProfileEditNicknameInteractor: ProfileEditNicknameBusinessLogic, ProfileEditNicknameDataStore {
+final class ProfileEditNicknameInteractor
+: ProfileEditNicknameBusinessLogic,
+  ProfileEditNicknameDataStore {
     private let presenter: ProfileEditNicknamePresentationLogic
     private let worker: ProfileEditNicknameWorkerProtocol
     private let externalDataStore: ProfileEditDataStore
@@ -30,12 +35,42 @@ final class ProfileEditNicknameInteractor: ProfileEditNicknameBusinessLogic, Pro
         self.worker = worker
         self.externalDataStore = externalDataStore
     }
-    
-    // MARK: - DataStore
 }
 
-// MARK: Feature ()
+// MARK: Feature
 
 extension ProfileEditNicknameInteractor {
-    
+    func loadIfNeeded() {
+        let profile = externalDataStore.editingProfile?.profileInfo
+        presenter.presentNickname(profile?.nickname)
+    }
+
+    func verifyNickname(_ nickname: String) {
+        var errorType: ProfileEditNickname.NicknameErrorType?
+
+        // 글자수 제한
+        let textCount = nickname.count
+        let textCountRange = (ProfileEditNickname.Const.nicknameMinCount...ProfileEditNickname.Const.nicknameMaxCount)
+        if textCountRange.contains(textCount) == false,
+           textCount != 0 {
+            errorType = .invalidTextCount
+        }
+        presentNicknameErrorIfNeeded(errorType)
+
+        // 한국어 이외 문자 제한
+        let koreanRegex = "^[가-힣ㄱ-ㅎㅏ-ㅣ]*$"
+        let predicate = NSPredicate(format:"SELF MATCHES %@", koreanRegex)
+        if predicate.evaluate(with: nickname) == false {
+            errorType = .invalidKorean
+        }
+        presentNicknameErrorIfNeeded(errorType)
+
+        if errorType == nil {
+            externalDataStore.editingProfile?.profileInfo.nickname = nickname
+        }
+    }
+
+    private func presentNicknameErrorIfNeeded(_ errorType: ProfileEditNickname.NicknameErrorType?) {
+        presenter.presentNicknameValidity(errorType: errorType)
+    }
 }

--- a/Projects/AppFeature/ProfileEdit/Targets/Scene/Sources/Scenes/Nickname/ProfileEditNicknameModels.swift
+++ b/Projects/AppFeature/ProfileEdit/Targets/Scene/Sources/Scenes/Nickname/ProfileEditNicknameModels.swift
@@ -11,5 +11,15 @@ import Foundation
 import AppCore_Entity
 
 enum ProfileEditNickname {
-    
+    enum NicknameErrorType {
+        case invalidKorean
+        case invalidTextCount
+        case duplicatedError
+        case explicitError
+    }
+
+    enum Const {
+        static let nicknameMinCount = 2
+        static let nicknameMaxCount = 8
+    }
 }

--- a/Projects/AppFeature/ProfileEdit/Targets/Scene/Sources/Scenes/Nickname/ProfileEditNicknamePresenter.swift
+++ b/Projects/AppFeature/ProfileEdit/Targets/Scene/Sources/Scenes/Nickname/ProfileEditNicknamePresenter.swift
@@ -10,7 +10,10 @@ import Foundation
 
 import SharedKit
 
-protocol ProfileEditNicknamePresentationLogic {}
+protocol ProfileEditNicknamePresentationLogic {
+    func presentNickname(_ nickname: String?)
+    func presentNicknameValidity(errorType: ProfileEditNickname.NicknameErrorType?)
+}
 
 final class ProfileEditNicknamePresenter {
     private weak var viewController: (any ProfileEditNicknameDisplayLogic)?
@@ -23,5 +26,30 @@ final class ProfileEditNicknamePresenter {
 // MARK: - Presentation Logic
 
 extension ProfileEditNicknamePresenter: ProfileEditNicknamePresentationLogic {
-    
+    func presentNickname(_ nickname: String?) {
+        viewController?.displayNickname(nickname)
+    }
+
+    func presentNicknameValidity(errorType: ProfileEditNickname.NicknameErrorType?) {
+        if let errorType {
+            viewController?.displayNicknameValidity(.invalid(errorType.errorText))
+        } else {
+            viewController?.displayNicknameValidity(.valid)
+        }
+    }
+}
+
+extension ProfileEditNickname.NicknameErrorType {
+    var errorText: String {
+        switch self {
+        case .invalidKorean:
+            return "한글만 입력가능합니다."
+        case .invalidTextCount:
+            return "2-8자 이내로 입력해주세요."
+        case .duplicatedError:
+            return "중복된 닉네임입니다. 다시 입력해주세요."
+        case .explicitError:
+            return "부적절한 닉네임입니다. 새로 입력해주세요."
+        }
+    }
 }

--- a/Projects/AppFeature/ProfileEdit/Targets/Scene/Sources/Scenes/Nickname/ProfileEditNicknameViewController.swift
+++ b/Projects/AppFeature/ProfileEdit/Targets/Scene/Sources/Scenes/Nickname/ProfileEditNicknameViewController.swift
@@ -60,6 +60,7 @@ final class ProfileEditNicknameViewController: ProfileEditViewController {
         headerView.configure(content: .nickname)
 
         nicknameInput.do {
+            $0.delegate = self
             $0.setMaxCount(Const.nicknameMaxCount)
             $0.updatePlaceholder(Const.nicknameInputPlaceholder)
 
@@ -102,6 +103,22 @@ extension ProfileEditNicknameViewController: ProfileEditNicknameDisplayLogic {
     func displayNicknameValidity(_ validity: InputField.Validity) {
         nicknameInput.updateValidity(validity)
         nextButton.isEnabled = validity == .valid || nicknameInput.text.isEmpty == false
+    }
+}
+
+// MARK: - InputDelegate
+
+extension ProfileEditNicknameViewController: InputDelegate {
+    func textField(
+        _ textField: UITextField,
+        shouldChangeCharactersIn range: NSRange,
+        replacementString string: String
+    ) -> Bool {
+        // Note: 띄워쓰기 금지
+        if string.contains(" ") {
+            return false
+        }
+        return true
     }
 }
 


### PR DESCRIPTION
### 📃 전달 사항

- 회원가입 플로우를 네 화면으로 나누어서 PR을 올려여.
- 네 화면 모두 공통적으로 사용되는 HeaderView / Keyboard 애니메이션 / 다음 버튼은 부모뷰컨에서 구현했어여


### 📸 스크린샷

<img src="https://github.com/telling-me/tellingme-iOS-new/assets/56102421/16bb2efd-0b2c-42b2-8024-0ef800816aa0" width="200">


### ✔ 진행사항
- [x] 닉네임 입력 화면 
- [ ] 출생연도 / 성별 입력 화면
- [ ] 직업 선택 화면
- [ ] 고민 선택 화면

### 🔴 ETC

x


### 💻 개발환경
macOS: Sonoma 14.0
xcode: 15.0
iOS: iphone 15 pro simulator


<hr>

closes: #
